### PR TITLE
implement PDF parsing endpoint with dual parser routing

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,0 +1,23 @@
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+def get_llama_api_key() -> str | None:
+    """
+    Returns the LlamaParse API key from the environment.
+    Returns None if the key is not set -- callers handle the None case
+    rather than crashing here, so the error message can be more specific.
+    """
+    return os.getenv("LLAMA_CLOUD_API_KEY")
+
+
+def llama_api_key_is_configured() -> bool:
+    """
+    Quick boolean check used by the classifier to decide
+    whether LlamaParse is actually available to use.
+    If the key is missing, the router falls back to pdfplumber
+    and attaches a warning rather than crashing.
+    """
+    key = get_llama_api_key()
+    return key is not None and len(key.strip()) > 0

--- a/backend/app/endpoints/upload_documents.py
+++ b/backend/app/endpoints/upload_documents.py
@@ -1,26 +1,97 @@
-from fastapi import APIRouter, UploadFile, File, HTTPException
-from app.schemas.document import DocumentResponse, TextChunk
-from app.services.pdf_engine import extract_text_from_pdf
+# backend/app/endpoints/upload_documents.py
+
+import tempfile
+import os
+import logging
+from typing import Literal
+
+from fastapi import APIRouter, UploadFile, File, Form, HTTPException
+from app.schemas.document import DocumentResponse, TextChunk, ParseClassification
+from app.services.pdf_engine import parse_pdf_smart
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
+
+MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024
+
 
 @router.post("/upload", response_model=DocumentResponse)
-async def upload_document(file: UploadFile = File(...)):
+async def upload_document(
+    file: UploadFile = File(...),
+    # guidance_level comes in as a form field alongside the file
+    guidance_level: Literal["light", "medium", "heavy"] = Form("medium"),
+):
     if file.content_type != "application/pdf":
-        raise HTTPException(status_code=400, detail="File must be a PDF")
-    
+        raise HTTPException(
+            status_code=400,
+            detail="Only PDF files are accepted. Please upload a file with a .pdf extension."
+        )
+
+    file_content = await file.read()
+
+    if len(file_content) > MAX_FILE_SIZE_BYTES:
+        raise HTTPException(
+            status_code=413,
+            detail="File is too large. Maximum allowed size is 10MB."
+        )
+
+    if len(file_content) == 0:
+        raise HTTPException(
+            status_code=400,
+            detail="The uploaded file is empty."
+        )
+
+    tmp_path = None
     try:
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".pdf") as tmp:
+            tmp.write(file_content)
+            tmp_path = tmp.name
 
-        file_content = await file.read()
-        raw_data = await extract_text_from_pdf(file_content)
+        parse_result = parse_pdf_smart(tmp_path)
 
+        classification = ParseClassification(
+            parser_used=parse_result["classification"]["parser"],
+            routing_reasons=parse_result["classification"]["reasons"],
+            signals=parse_result["classification"]["signals"],
+        )
+
+        elements = [
+            TextChunk(
+                text=elem["text"],
+                element_type=elem["element_type"],
+                page_number=elem.get("page_number"),
+                char_count=elem["char_count"],
+            )
+            for elem in parse_result["elements"]
+        ]
 
         return DocumentResponse(
             filename=file.filename or "unknown_document.pdf",
-            total_chunks=0,
-            chunks=None,
-            raw=raw_data,
+            total_elements=len(elements),
+            elements=elements,
+            classification=classification,
+            guidance_level=guidance_level,  # now passed in from the form field
+            low_text_warning=parse_result["low_text_warning"],
+            warning_message=parse_result.get("warning_message"),
         )
-    
+
+    except HTTPException:
+        raise
+
+    except RuntimeError as e:
+        logger.error(f"PDF extraction failed for {file.filename}: {e}")
+        raise HTTPException(
+            status_code=400,
+            detail="Could not extract text from this PDF. The file may be corrupt or password-protected."
+        )
+
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f'Erro processing PDF: {str(e)}')
+        logger.error(f"Unexpected error processing {file.filename}: {e}", exc_info=True)
+        raise HTTPException(
+            status_code=500,
+            detail="An unexpected error occurred while processing the document."
+        )
+
+    finally:
+        if tmp_path and os.path.exists(tmp_path):
+            os.unlink(tmp_path)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,7 +9,10 @@ app = FastAPI(title="FocusFlow API")
 
 # Configure CORS
 origins = [
-    "http://localhost:5173",  # For our frontend
+    "http://localhost:5173",
+    "http://localhost:5174",
+    "http://localhost:5175",
+    "http://localhost:5176",
 ]
 
 app.add_middleware(

--- a/backend/app/schemas/document.py
+++ b/backend/app/schemas/document.py
@@ -1,16 +1,30 @@
 from pydantic import BaseModel
-from typing import List, Optional, Any
+from typing import Optional, Literal
+
+
 class TextChunk(BaseModel):
-    chunk_id: int
-    title: str
-    key_idea: str
-    content: str
-    page_start: int
-    page_end: int
+    # The actual text content of this chunk
+    text: str
+    element_type: str = "text"
+    page_number: Optional[int] = None
+    char_count: int
+
+
+class ParseClassification(BaseModel):
+    parser_used: str
+    routing_reasons: list[str]
+    signals: dict
 
 
 class DocumentResponse(BaseModel):
     filename: str
-    total_chunks: int
-    chunks: Optional[List[TextChunk]] = [] 
-    raw: Optional[List[Any]] = None
+    # Total number of extracted elements before chunking
+    total_elements: int
+    # The extracted elements
+    elements: list[TextChunk]
+    # How the document was classified and which parser was selected
+    classification: ParseClassification
+    # The guidance level from the request
+    guidance_level: Literal["light", "medium", "heavy"]
+    low_text_warning: bool = False
+    warning_message: Optional[str] = None

--- a/backend/app/services/pdf_engine.py
+++ b/backend/app/services/pdf_engine.py
@@ -1,20 +1,306 @@
-import fitz
+import pdfplumber
+import os
+import logging
+import nest_asyncio
+from typing import Optional
 
-async def extract_text_from_pdf(file_content: bytes):
+from app.config import get_llama_api_key, llama_api_key_is_configured
 
-    doc = fitz.open(stream=file_content, filetype='pdf')
+# Apply at module load so LlamaParse can run inside FastAPI's event loop
+nest_asyncio.apply()
 
-    full_text = []
+logger = logging.getLogger(__name__)
 
-    for page_num, page in enumerate(doc):
-        text = page.get_text()
-        clean_text = text.replace("\n", ' ').strip()
 
-        if clean_text:
-            full_text.append({
-                "page": page_num + 1,
-                "text": clean_text
-            })
+# Classifier
+def classify_pdf(filepath: str) -> dict:
+    """
+    Lightweight pre-scan of the PDF to decide which parser to use.
+    Only samples the first 3 pages so this stays fast.
+    Returns the recommended parser and the reasoning behind the choice.
+    """
 
-    print(f'[Full_Text]: {full_text}')
-    return full_text
+    result = {
+        "parser": "pdfplumber",
+        "reasons": [],
+        "signals": {}
+    }
+
+    try:
+        with pdfplumber.open(filepath) as pdf:
+            total_pages = len(pdf.pages)
+
+            # Only sample first 3 pages to keep classification fast
+            sample_pages = pdf.pages[:min(3, total_pages)]
+
+            total_chars = 0
+            total_images = 0
+            empty_page_count = 0
+
+            for page in sample_pages:
+                text = page.extract_text() or ""
+                total_chars += len(text)
+
+                if hasattr(page, "images"):
+                    total_images += len(page.images)
+
+                if len(text.strip()) == 0:
+                    empty_page_count += 1
+
+            chars_per_page = (
+                total_chars / len(sample_pages) if sample_pages else 0
+            )
+
+            result["signals"] = {
+                "total_pages": total_pages,
+                "chars_sampled": total_chars,
+                "chars_per_page": round(chars_per_page, 1),
+                "images_found": total_images,
+                "empty_pages_in_sample": empty_page_count,
+                "llama_available": llama_api_key_is_configured(),
+            }
+
+            # Check all edge cases
+            # No text at all likely a scanned document
+            if total_chars == 0 or empty_page_count == len(sample_pages):
+                result["parser"] = "llamaparse"
+                result["reasons"].append(
+                    "No text layer detected -- document appears to be scanned or image-based"
+                )
+                return result
+
+            # Very sparse text
+            if chars_per_page < 100:
+                result["parser"] = "llamaparse"
+                result["reasons"].append(
+                    f"Very low text density ({total_chars} chars across "
+                    f"{len(sample_pages)} pages)"
+                )
+                return result
+
+            # Too many images relative to pages
+            if total_images > len(sample_pages) * 2:
+                result["parser"] = "llamaparse"
+                result["reasons"].append(
+                    f"High image density ({total_images} images across "
+                    f"{len(sample_pages)} pages)"
+                )
+                return result
+
+            # Two column layout detection
+            first_page = pdf.pages[0]
+            words = first_page.extract_words()
+
+            if words:
+                page_width = first_page.width
+                center = page_width / 2
+                margin = page_width * 0.05
+
+                left_words = [w for w in words if w["x1"] < center - margin]
+                right_words = [w for w in words if w["x0"] > center + margin]
+
+                left_ratio = len(left_words) / len(words)
+                right_ratio = len(right_words) / len(words)
+
+                if left_ratio > 0.3 and right_ratio > 0.3:
+                    result["parser"] = "llamaparse"
+                    result["reasons"].append(
+                        f"Two-column layout detected "
+                        f"({left_ratio:.0%} left, {right_ratio:.0%} right of words)"
+                    )
+                    return result
+
+            # No override triggered standard document is fine with pdfplumber
+            result["reasons"].append(
+                "Standard single-column text PDF -- fast parser is sufficient"
+            )
+
+    except Exception as e:
+        # If classification itself crashes default to llamaparse as the safer option
+        logger.warning(f"Classification failed: {e} -- defaulting to llamaparse")
+        result["parser"] = "llamaparse"
+        result["reasons"].append(
+            f"Classification failed ({str(e)}) -- defaulting to deep parser"
+        )
+
+    return result
+
+
+# Parsers
+def _parse_with_pdfplumber(filepath: str) -> dict:
+    """
+    Fast local parser for standard single-column text PDFs.
+    No API key required, runs entirely locally.
+    """
+
+    elements = []
+
+    try:
+        with pdfplumber.open(filepath) as pdf:
+            for page_num, page in enumerate(pdf.pages):
+                text = page.extract_text()
+
+                if not text or not text.strip():
+                    # Page has no text layer, skip it rather than crash
+                    logger.debug(f"Page {page_num + 1} returned no text from pdfplumber")
+                    continue
+
+                # Split on double newlines to get paragraph level blocks
+                # Abigail's chunker handles finer splitting downstream
+                paragraphs = [p.strip() for p in text.split("\n\n") if p.strip()]
+
+                for para in paragraphs:
+                    elements.append({
+                        "text": para,
+                        "element_type": "text",
+                        "page_number": page_num + 1,
+                        "char_count": len(para),
+                    })
+
+    except Exception as e:
+        raise RuntimeError(f"pdfplumber extraction failed: {str(e)}")
+
+    return {"elements": elements, "fallback_warning": None}
+
+
+def _parse_with_llamaparse(filepath: str) -> dict:
+    """
+    Deep parser for scanned documents, two-column layouts, and image-heavy PDFs.
+    Requires LLAMA_CLOUD_API_KEY in the .env file.
+    Falls back to pdfplumber if the key is missing, the API fails, or the response is empty.
+    """
+
+    # Check the key before making any network call
+    api_key = get_llama_api_key()
+    if not api_key or not api_key.strip():
+        logger.warning(
+            "LlamaParse was selected but LLAMA_CLOUD_API_KEY is not set in .env. "
+            "Falling back to pdfplumber."
+        )
+        fallback_result = _parse_with_pdfplumber(filepath)
+        fallback_result["fallback_warning"] = (
+            "This document type works best with our deep parser, but it is not "
+            "configured yet. Results may be less accurate for complex layouts."
+        )
+        return fallback_result
+
+    try:
+        from llama_parse import LlamaParse
+
+        parser = LlamaParse(
+            api_key=api_key,
+            result_type="markdown",
+            verbose=False,
+        )
+
+        documents = parser.load_data(filepath)
+
+        # Empty response from LlamaParse, fall back rather than return nothing
+        if not documents:
+            logger.warning("LlamaParse returned empty documents -- falling back to pdfplumber")
+            fallback_result = _parse_with_pdfplumber(filepath)
+            fallback_result["fallback_warning"] = (
+                "Deep parsing returned no content. Basic extraction was used instead."
+            )
+            return fallback_result
+
+        elements = []
+        for page_num, doc in enumerate(documents):
+            if not doc.text.strip():
+                continue
+
+            blocks = [b.strip() for b in doc.text.split("\n\n") if b.strip()]
+
+            for block in blocks:
+                # LlamaParse markdown headings start with # so classify them as Title
+                # so the chunker knows to keep them attached to what follows
+                if block.startswith("#"):
+                    element_type = "Title"
+                    clean_text = block.lstrip("#").strip()
+                else:
+                    element_type = "text"
+                    clean_text = block
+
+                elements.append({
+                    "text": clean_text,
+                    "element_type": element_type,
+                    "page_number": page_num + 1,
+                    "char_count": len(clean_text),
+                })
+
+        return {"elements": elements, "fallback_warning": None}
+
+    except ImportError:
+        # Package not installed
+        logger.error("llama-parse is not installed. Run: pip install llama-parse")
+        fallback_result = _parse_with_pdfplumber(filepath)
+        fallback_result["fallback_warning"] = (
+            "Deep parser package is not installed. Basic extraction was used instead."
+        )
+        return fallback_result
+
+    except Exception as e:
+        # Network error, auth error, timeout, anything unexpected from LlamaParse
+        logger.error(f"LlamaParse failed: {e} -- falling back to pdfplumber")
+        fallback_result = _parse_with_pdfplumber(filepath)
+        fallback_result["fallback_warning"] = (
+            "Deep parsing encountered an error and basic extraction was used instead. "
+            "Results may be less accurate for complex layouts."
+        )
+        return fallback_result
+
+
+# Router
+def parse_pdf_smart(filepath: str) -> dict:
+    """
+    The only function the endpoint calls.
+    Classifies the document, picks the right parser, runs it,
+    and evaluates the output quality before returning.
+    """
+
+    # Classify first
+    classification = classify_pdf(filepath)
+    chosen_parser = classification["parser"]
+
+    logger.info(f"Parser selected: {chosen_parser} | Reasons: {classification['reasons']}")
+
+    # If llamaparse was chosen but the key is not configured override now
+    if chosen_parser == "llamaparse" and not llama_api_key_is_configured():
+        logger.info(
+            "Classifier selected llamaparse but key is not configured -- "
+            "overriding to pdfplumber"
+        )
+        chosen_parser = "pdfplumber"
+        classification["reasons"].append(
+            "LlamaParse key not configured -- using fast parser instead"
+        )
+
+    # Route to the right parser
+    if chosen_parser == "llamaparse":
+        parse_result = _parse_with_llamaparse(filepath)
+    else:
+        parse_result = _parse_with_pdfplumber(filepath)
+
+    elements = parse_result["elements"]
+    fallback_warning = parse_result.get("fallback_warning")
+
+    # Evaluate output quality
+    total_chars = sum(e["char_count"] for e in elements)
+    low_text_warning = total_chars < 200
+
+    if fallback_warning:
+        warning_message = fallback_warning
+    elif low_text_warning:
+        warning_message = (
+            "Very little text was extracted from this document. "
+            "It may be a scanned image PDF. Try uploading a text-based version if available."
+        )
+    else:
+        warning_message = None
+
+    return {
+        "classification": classification,
+        "elements": elements,
+        "low_text_warning": low_text_warning,
+        "warning_message": warning_message,
+    }

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,5 @@ pymupdf
 langchain 
 langchain-google-genai 
 python-dotenv
+llama-parse
+nest-asyncio

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.env

--- a/frontend/src/components/UploadSetupView.tsx
+++ b/frontend/src/components/UploadSetupView.tsx
@@ -1,14 +1,40 @@
-import { useState } from 'react';
-import { FileText, Loader2 } from 'lucide-react';
-import Header from './Header';
-import GuidanceOption from './GuidanceOption';
-import FileUploader from './FileUploader';
+import { useState } from "react";
+import { FileText, Loader2, AlertTriangle } from "lucide-react";
+import Header from "./Header";
+import GuidanceOption from "./GuidanceOption";
+import FileUploader from "./FileUploader";
+
+interface ParsedDocument {
+  filename: string;
+  total_elements: number;
+  elements: {
+    text: string;
+    element_type: string;
+    page_number: number | null;
+    char_count: number;
+  }[];
+  classification: {
+    parser_used: string;
+    routing_reasons: string[];
+    signals: Record<string, unknown>;
+  };
+  low_text_warning: boolean;
+  warning_message: string | null;
+}
 
 export default function UploadSetupView() {
-  const [guidanceLevel, setGuidanceLevel] = useState('medium');
+  const [guidanceLevel, setGuidanceLevel] = useState("medium");
   const [file, setFile] = useState<File | null>(null);
   const [isUploading, setIsUploading] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);
+
+  // Stores the parsed document after a successful upload
+  const [parsedDocument, setParsedDocument] = useState<ParsedDocument | null>(
+    null
+  );
+
+  // Stores a non fatal warning from the backend
+  const [backendWarning, setBackendWarning] = useState<string | null>(null);
 
   const handleStartReading = async () => {
     if (!file) {
@@ -18,29 +44,51 @@ export default function UploadSetupView() {
 
     setIsUploading(true);
     setUploadError(null);
+    setBackendWarning(null);
+    setParsedDocument(null);
 
     const formData = new FormData();
     formData.append("file", file);
 
-    try {
+    // Send guidance_level alongside the file as a form field
+    formData.append("guidance_level", guidanceLevel);
 
-      const response = await fetch("http://localhost:8000/api/documents/upload", {
-        method: "POST",
-        body: formData,
-      });
+    try {
+      const response = await fetch(
+        "http://localhost:8000/api/documents/upload",
+        {
+          method: "POST",
+          body: formData,
+        }
+      );
+
+      // Parse the response body regardless of status
+      const data = await response.json();
 
       if (!response.ok) {
-        throw new Error(`Upload failed with status ${response.status}`);
+        // Surface that message directly to the user
+        throw new Error(
+          data.detail || `Upload failed with status ${response.status}`
+        );
       }
 
-      const data = await response.json();
-      console.log("Success! Backend returned:", data);
-      
-      // Logic of transitioning to another component/page goes below here
+      // Store the parsed document for the reading view
+      setParsedDocument(data);
 
+      if (data.low_text_warning && data.warning_message) {
+        setBackendWarning(data.warning_message);
+      }
+
+      // Transition to reading view here once it is built
+      // To be done soone
+      console.log("Parsed document ready:", data);
+      console.log("Guidance level selected:", guidanceLevel);
     } catch (error) {
-      console.error("Error uploading file:", error);
-      setUploadError("Failed to upload the document. Is the backend server running?");
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Failed to upload the document. Is the backend server running?";
+      setUploadError(message);
     } finally {
       setIsUploading(false);
     }
@@ -54,7 +102,9 @@ export default function UploadSetupView() {
         <div className="bg-blue-50/50 p-6 border-b border-slate-100">
           <div className="flex items-center gap-3 mb-1">
             <FileText className="w-6 h-6 text-indigo-500" />
-            <h3 className="text-lg font-semibold text-slate-900">Upload your Document</h3>
+            <h3 className="text-lg font-semibold text-slate-900">
+              Upload your Document
+            </h3>
           </div>
           <p className="text-sm text-slate-500 ml-9">
             Upload your PDF and customize your reading experience
@@ -62,51 +112,64 @@ export default function UploadSetupView() {
         </div>
 
         <div className="p-8 space-y-8">
-          
           <section className="space-y-3">
             <label className="block text-sm font-medium text-slate-900">
               Document Upload
             </label>
             <FileUploader file={file} setFile={setFile} />
-            
+
+            {/* Fatal upload error */}
             {uploadError && (
               <p className="text-sm text-red-500 mt-2">{uploadError}</p>
+            )}
+
+            {/* Non-fatal backend warning */}
+            {backendWarning && (
+              <div className="flex items-start gap-2 p-3 bg-amber-50 border border-amber-200 rounded-lg mt-2">
+                <AlertTriangle className="w-4 h-4 text-amber-500 mt-0.5 shrink-0" />
+                <p className="text-sm text-amber-700">{backendWarning}</p>
+              </div>
+            )}
+
+            {/* Success state */}
+            {parsedDocument && !backendWarning && (
+              <p className="text-sm text-green-600 mt-2">
+                Document processed successfully. {parsedDocument.total_elements}{" "}
+                sections extracted.
+              </p>
             )}
           </section>
 
           <section className="space-y-3">
-             <label className="block text-sm font-medium text-slate-900">
+            <label className="block text-sm font-medium text-slate-900">
               Guidance Level
             </label>
             <div className="space-y-3">
-              <GuidanceOption 
+              <GuidanceOption
                 id="light"
                 title="Light support"
                 description="Minimal interventions. Basic formatting and occasional check-ins."
-                selected={guidanceLevel === 'light'}
-                onClick={() => setGuidanceLevel('light')}
+                selected={guidanceLevel === "light"}
+                onClick={() => setGuidanceLevel("light")}
               />
-
-              <GuidanceOption 
+              <GuidanceOption
                 id="medium"
                 title="Medium Support (Recommended)"
                 description="Balanced guidance with clear chunking and tracking."
-                selected={guidanceLevel === 'medium'}
-                onClick={() => setGuidanceLevel('medium')}
+                selected={guidanceLevel === "medium"}
+                onClick={() => setGuidanceLevel("medium")}
               />
-
-              <GuidanceOption 
+              <GuidanceOption
                 id="heavy"
                 title="Heavy Support"
                 description="Frequent re-orientation, detailed context, and active reading assistance."
-                selected={guidanceLevel === 'heavy'}
-                onClick={() => setGuidanceLevel('heavy')}
-              /> 
-              
+                selected={guidanceLevel === "heavy"}
+                onClick={() => setGuidanceLevel("heavy")}
+              />
             </div>
           </section>
 
-          <button 
+          <button
             onClick={handleStartReading}
             disabled={isUploading || !file}
             className="w-full py-4 mt-4 text-white font-medium bg-indigo-500 hover:bg-indigo-600 rounded-xl transition-colors flex justify-center items-center disabled:opacity-50 disabled:cursor-not-allowed"


### PR DESCRIPTION
This implements the complete PDF parsing pipeline for FocusFlow. When a user uploads a PDF, the backend now classifies the document type, routes it to the appropriate parser, and returns structured elements ready for Abigail's chunking pipeline.

The classifier pre-scans the first 3 pages and checks four signals. Text density, image density, empty pages, and two-column layout. 

Based on those signals it routes to either pdfplumber (fast, local, standard documents) or LlamaParse (cloud, handles scanned PDFs, complex layouts, image-heavy docs). If LlamaParse fails for any reason it falls back to pdfplumber with a warning rather than returning a 500.